### PR TITLE
Fix/HM-99-v1-Bug Fix-Properties-Property edit

### DIFF
--- a/src/Properties/Properties.Infrastructure/Repositories/PropertiesRepository.cs
+++ b/src/Properties/Properties.Infrastructure/Repositories/PropertiesRepository.cs
@@ -162,6 +162,6 @@ namespace BuildingMarket.Properties.Infrastructure.Repositories
 
         public async Task<bool> IsOwner(string userId, int propertyId)
             => await _context.Properties
-                .AnyAsync(p => p.Id == propertyId && p.SellerId == userId);
+                .AnyAsync(p => p.Id == propertyId && (p.SellerId == userId || p.BrokerId == userId));
     }
 }


### PR DESCRIPTION
The brokers can now edit properties even if they are not the sellers.